### PR TITLE
Fixed the dynamic tag issue

### DIFF
--- a/pkg/channeld/connection.go
+++ b/pkg/channeld/connection.go
@@ -593,9 +593,7 @@ func (c *Connection) flush() {
 	tag := []byte{67, 72, 78, 76, byte(c.compressionType)}
 	len := len(bytes)
 	tag[3] = byte(len & 0xff)
-	if len > 0xff {
-		tag[2] = byte((len >> 8) & 0xff)
-	}
+	tag[2] = byte((len >> 8) & 0xff)
 	if len > MaxPacketSize {
 		// Should never happen, but log it just in case
 		c.Logger().Error("packet is oversized", zap.Int("size", len))

--- a/pkg/channeld/connection_test.go
+++ b/pkg/channeld/connection_test.go
@@ -67,6 +67,30 @@ func (c *pipelineConn) SetWriteDeadline(t time.Time) error {
 	return nil
 }
 
+func TestReadSize(t *testing.T) {
+	var tag []byte
+
+	tag = []byte{0, 0, 0, 0}
+	assert.Equal(t, 0, readSize(tag))
+	tag[3] = 1
+	assert.Equal(t, 0, readSize(tag))
+
+	tag = []byte{67, 0, 0, 0}
+	assert.Equal(t, 0, readSize(tag))
+	tag[3] = 1
+	assert.Equal(t, 0, readSize(tag))
+
+	tag = []byte{67, 72, 78, 0}
+	assert.Equal(t, 78<<8, readSize(tag))
+	tag[3] = 1
+	assert.Equal(t, 78<<8+1, readSize(tag))
+
+	tag = []byte{67, 72, 0, 0}
+	assert.Equal(t, 0, readSize(tag))
+	tag[3] = 1
+	assert.Equal(t, 1, readSize(tag))
+}
+
 func TestDropPacket(t *testing.T) {
 	pipeReader, pipeWriter := io.Pipe()
 	c := &Connection{
@@ -123,6 +147,8 @@ func TestWebSocketConnection(t *testing.T) {
 }
 
 func TestConcurrentAccessConnections(t *testing.T) {
+	InitConnections("../../config/server_conn_fsm_test.json", "../../config/client_non_authoratative_fsm.json")
+
 	wg := sync.WaitGroup{}
 
 	wg.Add(1)


### PR DESCRIPTION
- Simplified the read/write of package size in the tag;
- Message pack will be put back to the queue when potential oversize is detected in flush();
- Added unit tests for readSize();
- Removed out-dated commented code;