### PR TITLE
Fix message lost

### DIFF
--- a/pkg/channeld/channel.go
+++ b/pkg/channeld/channel.go
@@ -293,12 +293,13 @@ func (ch *Channel) Tick() {
 			return
 		}
 
+		tickStart := time.Now()
+
 		// Run the code of SpatialController only in GLOBAL channel, to avoid any race condition.
 		if ch.channelType == channeldpb.ChannelType_GLOBAL && spatialController != nil {
 			spatialController.Tick()
 		}
 
-		tickStart := time.Now()
 		ch.tickFrames++
 
 		ch.tickMessages(tickStart)

--- a/pkg/channeld/data_test.go
+++ b/pkg/channeld/data_test.go
@@ -135,6 +135,37 @@ func TestFanOutChannelData(t *testing.T) {
 	assert.Equal(t, 2, len(c2.testQueue()))
 	assert.EqualValues(t, "c", c1.latestMsg().(*testpb.TestChannelDataMessage).Text)
 	assert.EqualValues(t, "c", c2.latestMsg().(*testpb.TestChannelDataMessage).Text)
+
+	u3 := &testpb.TestChannelDataMessage{Text: "d"}
+	testChannel.Data().OnUpdate(u3, channelStartTime.AddMs(205), c2.Id(), nil)
+	testChannel.tickData(channelStartTime.AddMs(210))
+	assert.Equal(t, 3, len(c1.testQueue()))
+	assert.Equal(t, 2, len(c2.testQueue()))
+	assert.EqualValues(t, "c", c1.latestMsg().(*testpb.TestChannelDataMessage).Text)
+	assert.EqualValues(t, "c", c2.latestMsg().(*testpb.TestChannelDataMessage).Text)
+
+	testChannel.tickData(channelStartTime.AddMs(250))
+
+	assert.Equal(t, 4, len(c1.testQueue()))
+	assert.Equal(t, 3, len(c2.testQueue()))
+	assert.EqualValues(t, "d", c1.latestMsg().(*testpb.TestChannelDataMessage).Text)
+	assert.EqualValues(t, "d", c2.latestMsg().(*testpb.TestChannelDataMessage).Text)
+
+	u4 := &testpb.TestChannelDataMessage{Text: "e"}
+	testChannel.Data().OnUpdate(u4, channelStartTime.AddMs(206), c1.Id(), nil)
+	testChannel.tickData(channelStartTime.AddMs(300))
+
+	assert.Equal(t, 5, len(c1.testQueue()))
+	assert.Equal(t, 3, len(c2.testQueue()))
+	assert.EqualValues(t, "e", c1.latestMsg().(*testpb.TestChannelDataMessage).Text)
+	assert.EqualValues(t, "d", c2.latestMsg().(*testpb.TestChannelDataMessage).Text)
+
+	testChannel.tickData(channelStartTime.AddMs(350))
+
+	assert.Equal(t, 5, len(c1.testQueue()))
+	assert.Equal(t, 4, len(c2.testQueue()))
+	assert.EqualValues(t, "e", c1.latestMsg().(*testpb.TestChannelDataMessage).Text)
+	assert.EqualValues(t, "e", c2.latestMsg().(*testpb.TestChannelDataMessage).Text)
 }
 
 func BenchmarkCustomMergeMap(b *testing.B) {


### PR DESCRIPTION
there's some situations where channeld may go wrong.
1. msg receive time is set by receive goroutine, and later is used to determine if the message will be faned out. there's a gap between the receive and actual fanout, which may cause the fanout logic incorrectly ignore that message.
2. only message in the range [foc.lastFanoutTime,  foc.lastFanoutTime + cs.options.FanoutIntervalMs]  is faned out,  then foc.lastFanoutTime is set to the exact_time_of_that_fanout_excuted. which leaves a gap between  foc.lastFanoutTime + cs.options.FanoutIntervalMs and exact_time_of_that_fanout_excuted. if message arrived in that interval, that will be ignored.
this happends on my windows pc, channel/fanout  intervals are both 20ms, but due to the [sleep resolution problem](https://github.com/golang/go/issues/44343)，the chanel tick takes about 30 ms. In the tickData function, only msgs received in first 20ms are sent out, then lastFanoutTime is set to current time, causing some messages ignored forever.
3. if multi connections write to one channel, the arrivalTime of messages in the inMsgQueue will not be guaranteed in an  increasing order

by adding a message index which is incremented only by one goroutine to every message in channel, we can easily solve these problems.